### PR TITLE
rust-embed-based static inclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ base64 = "0.13.0"
 nom = { version = "6.2.1", features = ["regexp"] }
 lazy_static = "1.4.0"
 html-escape = "0.2.9"
+rust-embed = { version = "6.0.0", features = ["interpolate-folder-path"] }
+
+[features]
+embed-compression = ["rust-embed/compression"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,13 @@ use rocket_dyn_templates::{Template, tera::Tera};
 use tempfile::NamedTempFile;
 use std::sync::Mutex;
 
+use crate::static_include::static_file;
+
 mod actions;
 mod discord;
 mod matrix;
 mod generic;
+mod static_include;
 
 #[derive(FromForm)]
 pub struct Password {
@@ -176,23 +179,10 @@ fn rocket() -> _ {
                 post_decrypt,
                 post_jump,
                 post_messages,
-                post_search
+                post_search,
+                static_file
             ],
         )
-        .mount(
-            "/styles",
-            FileServer::from(relative!("static/styles"))
-        )
-        .mount(
-            "/scripts",
-            FileServer::from(relative!("static/scripts"))
-        )
-        .mount(
-            "/fonts",
-            FileServer::from(relative!("static/fonts"))
-        )
-        .mount("/images", FileServer::from(relative!("static/images")))
-        .mount("/", FileServer::from(actions::refrigerator()).rank(20))
         .attach(Template::custom(|engines| customize(&mut engines.tera)))
         .manage(Mutex::new(DBFile {backup_path: String::new(), file: None}))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ extern crate rocket;
 extern crate serde_derive;
 
 use dotenv::dotenv;
-use rocket::{http::CookieJar, form::Form, response::Redirect, serde::json::Json, fs::{FileServer, relative}, Config, State};
+use rocket::{http::CookieJar, form::Form, response::Redirect, serde::json::Json, Config, State};
 use rocket_dyn_templates::{Template, tera::Tera};
 use tempfile::NamedTempFile;
 use std::sync::Mutex;

--- a/src/static_include.rs
+++ b/src/static_include.rs
@@ -1,92 +1,26 @@
-use std::path::Path;
+use std::{borrow::Cow, ffi::OsStr, path::PathBuf};
 
 use rocket::{
-    handler::Outcome,
-    http::{uri::Segments, ContentType, Method, Status},
-    outcome::IntoOutcome,
-    response, Data, Handler, Request, Route,
+    get,
+    http::{ContentType, Status},
 };
+use rust_embed::RustEmbed;
 
-#[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StaticFiles<const N: usize> {
-    pub files: [File; N],
-    pub rank: isize,
-    pub root: &'static Path,
-}
+#[derive(Clone, Copy, Debug, RustEmbed)]
+#[folder = "$CARGO_MANIFEST_DIR/static"]
+#[exclude = "*.scss"]
+#[exclude = "*.ts"]
+struct Assets;
 
-impl<const N: usize> StaticFiles<N> {
-    pub fn rank(self, rank: isize) -> Self {
-        StaticFiles { rank, ..self }
-    }
-
-    pub fn root(self, root: &'static Path) -> Self {
-        StaticFiles { root, ..self }
-    }
-}
-
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct File {
-    pub path: &'static Path,
-    pub body: &'static [u8],
-}
-
-#[macro_export]
-macro_rules! include_static {
-    ($($path:literal),* $(,)?) => {
-        crate::static_include::StaticFiles {
-            files: [
-                $(
-                    crate::static_include::File {
-                        path: std::path::Path::new($path),
-                        body: include_bytes!(concat![env!("CARGO_MANIFEST_DIR"), "/", $path])
-                    }
-                ),*
-            ],
-            rank: 10,
-            root: std::path::Path::new("static"),
-        }
-    }
-}
-
-impl<'r> response::Responder<'r> for File {
-    fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let mut response = self.body.respond_to(req)?;
-        if let Some(ext) = self.path.extension() {
-            if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
-                response.set_header(ct);
-            }
-        }
-        Ok(response)
-    }
-}
-
-impl<const N: usize> Handler for StaticFiles<N> {
-    fn handle<'r>(&self, request: &'r Request, _data: Data) -> Outcome<'r> {
-        let req_path = request
-            .get_segments::<Segments>(0)
-            .and_then(Result::ok)
-            .and_then(|segments| segments.into_path_buf(false).ok())
-            .into_outcome(Status::NotFound)?;
-
-        Outcome::from(
-            request,
-            self.files
-                .iter()
-                .copied()
-                .find(|File { path, .. }| req_path == path.file_name().unwrap()),
-        )
-    }
-}
-
-impl<const N: usize> From<StaticFiles<N>> for Vec<Route> {
-    fn from(static_files: StaticFiles<N>) -> Vec<Route> {
-        vec![Route::ranked(
-            static_files.rank,
-            Method::Get,
-            "/<path..>",
-            static_files,
-        )]
-    }
+#[get("/<file..>", rank = 10)]
+pub fn static_file<'r>(file: PathBuf) -> Result<(ContentType, Cow<'static, [u8]>), Status> {
+    let filename = file.display().to_string();
+    let d = Assets::get(&filename).ok_or(Status::NotFound)?;
+    let ext = file
+        .as_path()
+        .extension()
+        .and_then(OsStr::to_str)
+        .ok_or(Status::InternalServerError)?;
+    let content_type = ContentType::from_extension(ext).ok_or(Status::InternalServerError)?;
+    Ok((content_type, d.data))
 }


### PR DESCRIPTION
Updated for Rocket 0.5

Includes `embed-compression` feature which decreases binary size at the cost of server startup time.
Did not enable this by default, as it only decreases size by 1.1% on my machine as of a2f035c1edf7bc94d2fbfa0c8b69f1d8d78826cf.

Overall size of binary as of a2f035c1edf7bc94d2fbfa0c8b69f1d8d78826cf is ~19M.

Debug builds do not embed files, significantly speeding up compile times by around 69%.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo build` | 74.175 ± 0.151 | 74.006 | 74.297 | 1.00 |
| `cargo build --release` | 125.075 ± 3.674 | 120.845 | 127.478 | 1.69 ± 0.05 |
